### PR TITLE
Base entity 추가

### DIFF
--- a/src/main/java/com/delivery/justonebite/JustonebiteApplication.java
+++ b/src/main/java/com/delivery/justonebite/JustonebiteApplication.java
@@ -2,8 +2,10 @@ package com.delivery.justonebite;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class JustonebiteApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/delivery/justonebite/common/entity/BaseEntity.java
+++ b/src/main/java/com/delivery/justonebite/common/entity/BaseEntity.java
@@ -6,7 +6,9 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -29,5 +31,16 @@ public abstract class BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private Long createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    @Column(name = "deleted_by")
+    private Long deletedBy;
 
 }

--- a/src/main/java/com/delivery/justonebite/common/entity/BaseEntity.java
+++ b/src/main/java/com/delivery/justonebite/common/entity/BaseEntity.java
@@ -1,4 +1,33 @@
 package com.delivery.justonebite.common.entity;
 
-public  abstract class BaseEntity {
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
 }


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #4 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 공통 베이스 엔티티 BaseEntity 추가
- 생성/수정/삭제 일시를 모든 도메인 엔티티에서 공통으로 사용할 수 있도록 표준화

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
