### PR TITLE
feat: 글로벌 예외 처리 도입 및 표준 에러 응답 일부  추가

### DIFF
--- a/src/main/java/com/delivery/justonebite/exception/custom/CustomException.java
+++ b/src/main/java/com/delivery/justonebite/exception/custom/CustomException.java
@@ -1,0 +1,29 @@
+package com.delivery.justonebite.exception.custom;
+
+import com.delivery.justonebite.exception.response.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String description;
+    private final HttpStatus status;
+
+
+    public CustomException(ErrorCode errorCode){
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+        this.description = errorCode.getDescription();
+        this.status = errorCode.getStatus();
+    }
+
+    public CustomException(ErrorCode errorCode, String description){
+        super(description);
+        this.errorCode = errorCode;
+        this.description = description;
+        this.status = errorCode.getStatus();
+    }
+
+}

--- a/src/main/java/com/delivery/justonebite/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/delivery/justonebite/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,72 @@
+package com.delivery.justonebite.exception.handler;
+
+import com.delivery.justonebite.exception.custom.CustomException;
+import com.delivery.justonebite.exception.response.ErrorResponse;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import static com.delivery.justonebite.exception.response.ErrorCode.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /** 도메인 예외 */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return ResponseEntity.status(e.getStatus())
+                .body(new ErrorResponse(e.getErrorCode()));
+    }
+
+    /** @Valid 바디 검증 실패 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        String description = e.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .findFirst().orElse(INVALID_INPUT_DATA.getDescription());
+        return ResponseEntity.status(BAD_REQUEST)
+                .body(new ErrorResponse(INVALID_INPUT_DATA, description));
+    }
+
+    /** 잘못된 요청 형식: 파라미터 누락/타입 불일치/본문 파싱 실패 */
+    @ExceptionHandler({
+            MissingServletRequestParameterException.class,
+            MethodArgumentTypeMismatchException.class,
+            HttpMessageNotReadableException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception e) {
+        return ResponseEntity.status(INVALID_INPUT_DATA.getStatus())
+                .body(new ErrorResponse(INVALID_INPUT_DATA, e.getMessage()));
+    }
+
+    /** 미지원 메서드(405) */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity.status(METHOD_NOT_ALLOWED.getStatus())
+                .body(new ErrorResponse(METHOD_NOT_ALLOWED, e.getMessage()));
+    }
+
+    /** DB 무결성/중복키(409) */
+    @ExceptionHandler({DataIntegrityViolationException.class, DuplicateKeyException.class})
+    public ResponseEntity<ErrorResponse> handleDataIntegrity(Exception e) {
+        return ResponseEntity.status(DATA_INTEGRITY_VIOLATION.getStatus())
+                .body(new ErrorResponse(DATA_INTEGRITY_VIOLATION, "데이터 무결성에 위배되었습니다."));
+    }
+
+    /** 그 밖의 예외(500) */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        e.printStackTrace();
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR.getStatus())
+                .body(new ErrorResponse(INTERNAL_SERVER_ERROR));
+    }
+
+}

--- a/src/main/java/com/delivery/justonebite/exception/response/ErrorCode.java
+++ b/src/main/java/com/delivery/justonebite/exception/response/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.delivery.justonebite.exception.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 예외가 생길때마다 이런식으로 추가
+    // 인증/인가
+    INVALID_MEMBER("유효하지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    NOT_VALID_TOKEN("토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_TOKEN("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN_ACCESS("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    // 공통
+    INVALID_INPUT_DATA("잘못된 입력 데이터입니다.", HttpStatus.BAD_REQUEST),
+    DATA_INTEGRITY_VIOLATION("데이터 무결성에 위배되었습니다.", HttpStatus.CONFLICT),
+    UNSUPPORTED_MEDIA_TYPE_ERROR("지원하지 않는 미디어 타입입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
+    RESOURCE_NOT_FOUND("리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INTERNAL_SERVER_ERROR("서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    METHOD_NOT_ALLOWED("지원하지 않는 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+
+
+
+    ;
+
+    private final String description;
+    private final HttpStatus status;
+
+}

--- a/src/main/java/com/delivery/justonebite/exception/response/ErrorResponse.java
+++ b/src/main/java/com/delivery/justonebite/exception/response/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.delivery.justonebite.exception.response;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private ErrorCode errorCode;
+    private String description;
+    private int status;
+
+    public ErrorResponse(ErrorCode errorCode){
+        this.errorCode = errorCode;
+        this.description = errorCode.getDescription();
+        this.status = errorCode.getStatus().value();
+    }
+
+    public ErrorResponse(ErrorCode errorCode, String description){
+        this.errorCode = errorCode;
+        this.description = description;
+        this.status = errorCode.getStatus().value();
+    }
+}


### PR DESCRIPTION
- GlobalExceptionHandler 추가
  - CustomException, @Valid 실패, 잘못된 요청 형식, 미지원 메서드, DataIntegrityViolation/DuplicateKey, 기타 예외 매핑
- ErrorCode/CustomException/ErrorResponse 정의

# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #1 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 전역 예외 처리 도입 및 표준 에러 응답 포맷 적용

## 💫 타입

 - [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
