### PR TITLE
feat(review):리뷰 조회 기능 추가 (단건 조회 / 가게별 목록)

### DIFF
--- a/src/main/java/com/delivery/justonebite/review/application/service/ReviewService.java
+++ b/src/main/java/com/delivery/justonebite/review/application/service/ReviewService.java
@@ -10,12 +10,15 @@ import com.delivery.justonebite.order.domain.repository.OrderRepository;
 import com.delivery.justonebite.review.entity.Review;
 import com.delivery.justonebite.review.presentation.dto.request.CreateReviewRequest;
 import com.delivery.justonebite.review.presentation.dto.response.CreateReviewResponse;
+import com.delivery.justonebite.review.presentation.dto.response.ReviewResponse;
 import com.delivery.justonebite.review.repository.ReviewRepository;
 import com.delivery.justonebite.shop.domain.repository.ShopRepository;
 import com.delivery.justonebite.user.domain.entity.UserRole;
 import jakarta.persistence.PreUpdate;
 import lombok.RequiredArgsConstructor;
 //import lombok.var;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +51,19 @@ public class ReviewService {
         Review review = buildReview(order, currentUserId, request);
         Review saved = reviewRepository.save(review);
         return CreateReviewResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewResponse getById(UUID reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+        return ReviewResponse.from(review);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReviewResponse> getByShop(UUID shopId, Pageable pageable) {
+        return reviewRepository.findByShopId(shopId, pageable)
+                .map(ReviewResponse::from);
     }
 
     private void validateCanWrite(UserRole role) {

--- a/src/main/java/com/delivery/justonebite/review/entity/Review.java
+++ b/src/main/java/com/delivery/justonebite/review/entity/Review.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Check;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Where;
 import org.hibernate.type.SqlTypes;
 
 import java.util.UUID;
@@ -25,6 +26,7 @@ import java.util.UUID;
                 @Index(name = "IDX_h_review_shop_id", columnList = "shop_id")
         }
 )
+@Where(clause = "deleted_at IS NULL")
 @Check(constraints = "rating BETWEEN 1 AND 5")
 @Getter
 @SuperBuilder
@@ -40,6 +42,10 @@ public class Review extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "order_id", insertable = false, updatable = false)
+    private UUID orderIdRef;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -62,7 +68,7 @@ public class Review extends BaseEntity {
         return Review.builder()
                 .order(order)
                 .userId(userId)
-//                .shopId(order.getShop()) TODO: shop도메인 구현하면 주석 해제
+                .shopId(order.getShop().getId())
                 .content(content)
                 .rating(rating)
                 .build();

--- a/src/main/java/com/delivery/justonebite/review/presentation/controller/ReviewController.java
+++ b/src/main/java/com/delivery/justonebite/review/presentation/controller/ReviewController.java
@@ -4,9 +4,15 @@ import com.delivery.justonebite.global.common.security.UserDetailsImpl;
 import com.delivery.justonebite.review.application.service.ReviewService;
 import com.delivery.justonebite.review.presentation.dto.request.CreateReviewRequest;
 import com.delivery.justonebite.review.presentation.dto.response.CreateReviewResponse;
+import com.delivery.justonebite.review.presentation.dto.response.ReviewResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +21,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +39,22 @@ public class ReviewController {
         CreateReviewResponse body =
                 reviewService.createReview(principal.getUserId(), principal.getUserRole(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ReviewResponse> getOne(@PathVariable UUID id) {
+        ReviewResponse body = reviewService.getById(id);
+        return ResponseEntity.status(HttpStatus.OK).body(body);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<ReviewResponse>> getByShopParam(
+            @RequestParam("shopId") UUID shopId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable) {
+
+        Page<ReviewResponse> body = reviewService.getByShop(shopId, pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(body);
     }
 
 }

--- a/src/main/java/com/delivery/justonebite/review/presentation/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/delivery/justonebite/review/presentation/dto/request/CreateReviewRequest.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 
 public record CreateReviewRequest(
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        @NotNull(message = "주문 ID는 필수입니다.")
         UUID orderId,
         UUID shopId,
         @NotBlank(message = "내용은 필수입니다.")

--- a/src/main/java/com/delivery/justonebite/review/presentation/dto/response/ReviewResponse.java
+++ b/src/main/java/com/delivery/justonebite/review/presentation/dto/response/ReviewResponse.java
@@ -1,0 +1,33 @@
+package com.delivery.justonebite.review.presentation.dto.response;
+
+import com.delivery.justonebite.review.entity.Review;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReviewResponse(
+        UUID reviewId,
+        UUID orderId,
+        UUID id, Long userId,
+        UUID shopId,
+        String content,
+        int rating,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        Long createdBy
+) {
+    public static ReviewResponse from(Review r) {
+        return new ReviewResponse(
+                r.getReviewId(),
+                r.getOrderIdRef(),
+                r.getOrder().getId(),
+                r.getUserId(),
+                r.getShopId(),
+                r.getContent(),
+                r.getRating(),
+                r.getCreatedAt(),
+                r.getUpdatedAt(),
+                r.getCreatedBy()
+        );
+    }
+}

--- a/src/main/java/com/delivery/justonebite/review/repository/ReviewRepository.java
+++ b/src/main/java/com/delivery/justonebite/review/repository/ReviewRepository.java
@@ -1,6 +1,8 @@
 package com.delivery.justonebite.review.repository;
 
 import com.delivery.justonebite.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,7 +12,12 @@ import java.util.UUID;
 public interface ReviewRepository extends JpaRepository<Review, UUID>{
 
     boolean existsByOrder_Id(UUID orderId);
+
     Optional<Review> findByOrder_Id(UUID orderId);
+
+    Optional<Review> findById(UUID id);
+
+    Page<Review> findByShopId(UUID shopId, Pageable pageable);
 
 
 }


### PR DESCRIPTION
# 🌟 조회 기능 추가 (단건 조회 / 가게별 목록)

## 🌐 이슈 번호
- #29 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- GET /v1/reviews/{id} 단건 조회
- GET /v1/reviews?shopId=... 가게별 리뷰 목록 조회 (페이지네이션)
- @Where(deleted_at IS NULL)로 소프트 삭제 리뷰 자동 제외
- 목록 변환 시 orderIdRef 사용으로 N+1 방지


## 🎸기타
생성/삭제/권한/집계는 후속 PR에서 구현예정

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
