### PR TITLE
refactor:리뷰 삭제및 복구는 작성자만 가능하도록 변경

### DIFF
--- a/src/main/java/com/delivery/justonebite/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/delivery/justonebite/global/common/entity/BaseEntity.java
@@ -48,6 +48,10 @@ public abstract class BaseEntity {
         this.deletedBy = deleterId;
     }
 
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
     public void restoreDeletion() {
         this.deletedAt = null;
         this.deletedBy = null;

--- a/src/main/java/com/delivery/justonebite/global/exception/response/ErrorCode.java
+++ b/src/main/java/com/delivery/justonebite/global/exception/response/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
     REVIEW_NOT_FOUND("리뷰를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     REVIEW_ALREADY_EXISTS("해당 주문에는 이미 리뷰가 존재합니다.", HttpStatus.CONFLICT),
     ORDER_NOT_COMPLETED("주문이 아직 완료상태가 아닙니다.", HttpStatus.FORBIDDEN),
+    ALREADY_DELETED_REVIEW("이미 삭제된 리뷰입니다.", HttpStatus.CONFLICT),
+    ALREADY_ACTIVE_REVIEW("이미 삭제되지 않은 리뷰입니다.", HttpStatus.CONFLICT),
 
 
     //주문

--- a/src/main/java/com/delivery/justonebite/review/application/service/ReviewService.java
+++ b/src/main/java/com/delivery/justonebite/review/application/service/ReviewService.java
@@ -77,24 +77,32 @@ public class ReviewService {
     }
 
     @Transactional
-    public void softDelete(UUID reviewId, Long currentUserId, UserRole currentUserRole) {
+    public void softDelete(UUID reviewId, Long currentUserId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
 
-        assertDeletable(review, currentUserId, currentUserRole);
+        assertDeletable(review, currentUserId);
+
+        if (review.isDeleted()) {
+            throw new CustomException(ErrorCode.ALREADY_DELETED_REVIEW);
+        }
         review.softDelete(currentUserId);
     }
 
     @Transactional
-    public void restore(UUID reviewId, Long currentUserId, UserRole currentUserRole) {
-        assertAdmin(currentUserRole);
-
+    public void restore(UUID reviewId, Long currentUserId) {
         Review review = reviewRepository.findByIdIncludingDeleted(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
 
+        if (!review.getUserId().equals(currentUserId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
+        if (!review.isDeleted()) {
+            throw new CustomException(ErrorCode.ALREADY_ACTIVE_REVIEW);
+        }
         review.restore();
     }
-
 
     private void validateCanWrite(UserRole role) {
         boolean canWrite = role == UserRole.CUSTOMER || role == UserRole.MANAGER || role == UserRole.MASTER;
@@ -155,10 +163,8 @@ public class ReviewService {
         if (req.rating() != null)  review.updateRating(req.rating());
     }
 
-    private void assertDeletable(Review review, Long userId, UserRole role) {
-        boolean isAuthor = review.getUserId().equals(userId);
-        boolean isAdmin = (role == UserRole.MANAGER || role == UserRole.MASTER);
-        if (!isAuthor && !isAdmin) {
+    private void assertDeletable(Review review, Long userId) {
+        if (!review.getUserId().equals(userId)) {
             throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
     }

--- a/src/main/java/com/delivery/justonebite/review/presentation/controller/ReviewController.java
+++ b/src/main/java/com/delivery/justonebite/review/presentation/controller/ReviewController.java
@@ -73,15 +73,14 @@ public class ReviewController {
     @DeleteMapping("/{id}")
     public ResponseEntity<DeleteReviewResponse> softDelete(@PathVariable("id") UUID id,
                                                            @AuthenticationPrincipal UserDetailsImpl principal) {
-        reviewService.softDelete(id, principal.getUserId(), principal.getUser().getUserRole());
+        reviewService.softDelete(id, principal.getUserId());
         return ResponseEntity.status(HttpStatus.OK).body(DeleteReviewResponse.ok(id));
     }
 
     @PostMapping("/{id}/restore")
     public ResponseEntity<RestoreReviewResponse> restore(@PathVariable("id") UUID id,
                                                          @AuthenticationPrincipal UserDetailsImpl principal) {
-        reviewService.restore(id, principal.getUserId(), principal.getUser().getUserRole());
+        reviewService.restore(id, principal.getUserId());
         return ResponseEntity.status(HttpStatus.OK).body(RestoreReviewResponse.ok(id));
     }
-
 }


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #60 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 리뷰 삭제 및 복구는 작성자만 가능

## 💫 타입

- [ ] 기능
- [ ] 버그
- [x ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
