### PR TITLE
feat: 주문 취소 기능

### DIFF
--- a/src/main/java/com/delivery/justonebite/global/exception/response/ErrorCode.java
+++ b/src/main/java/com/delivery/justonebite/global/exception/response/ErrorCode.java
@@ -48,11 +48,13 @@ public enum ErrorCode {
     ORDER_NOT_FOUND("주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ORDER_STATUS_NOT_FOUND("주문상태를 확인할수 없습니다", HttpStatus.NOT_FOUND),
     INVALID_ITEM("존재하지 않는 상품입니다.", HttpStatus.NOT_FOUND),
-    INVALID_USER_ROLE("유효하지 않은 회원 유형입니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_ORDER_STATUS("유효하지 않은 주문 상태입니다.", HttpStatus.UNAUTHORIZED),
-    TOTAL_PRICE_NOT_MATCH("전체 주문금액이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    ORDER_STATUS_CANCEL_NOT_ALLOWED("취소할 수 없는 주문 상태입니다.", HttpStatus.UNAUTHORIZED),
-    ORDER_CANCEL_TIME_EXCEEDED("주문 시점으로부터 5분이 경과하여 취소할 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_USER_ROLE("유효하지 않은 회원 유형입니다.", HttpStatus.FORBIDDEN),
+    INVALID_ORDER_STATUS("유효하지 않은 주문 상태입니다.", HttpStatus.BAD_REQUEST),
+    TOTAL_PRICE_NOT_MATCH("전체 주문금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ORDER_STATUS_CANCEL_NOT_ALLOWED("취소할 수 없는 주문 상태입니다.", HttpStatus.BAD_REQUEST),
+    ORDER_CANCEL_TIME_EXCEEDED("주문 시점으로부터 5분이 경과하여 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ORDER_USER_NOT_MATCH("주문 상의 주문자와 동일한 회원이 아닙니다.", HttpStatus.FORBIDDEN),
+    INVALID_CANCEL_STATUS_VALUE("취소 요청 상태는 ORDER_CANCELLED 여야 합니다.", HttpStatus.BAD_REQUEST),
 
     ;
 

--- a/src/main/java/com/delivery/justonebite/order/application/service/OrderService.java
+++ b/src/main/java/com/delivery/justonebite/order/application/service/OrderService.java
@@ -6,33 +6,28 @@ import com.delivery.justonebite.item.domain.entity.Item;
 import com.delivery.justonebite.item.domain.repository.ItemRepository;
 import com.delivery.justonebite.order.domain.entity.Order;
 import com.delivery.justonebite.order.domain.entity.OrderHistory;
-import com.delivery.justonebite.order.domain.entity.OrderItem;
 import com.delivery.justonebite.order.domain.enums.OrderStatus;
 import com.delivery.justonebite.order.domain.factory.OrderFactory;
 import com.delivery.justonebite.order.domain.repository.OrderHistoryRepository;
 import com.delivery.justonebite.order.domain.repository.OrderItemRepository;
 import com.delivery.justonebite.order.domain.repository.OrderRepository;
 import com.delivery.justonebite.order.presentation.dto.OrderItemDto;
+import com.delivery.justonebite.order.presentation.dto.request.CancelOrderRequest;
 import com.delivery.justonebite.order.presentation.dto.request.CreateOrderRequest;
 import com.delivery.justonebite.order.presentation.dto.request.UpdateOrderStatusRequest;
 import com.delivery.justonebite.order.presentation.dto.response.CustomerOrderResponse;
 import com.delivery.justonebite.order.presentation.dto.response.GetOrderStatusResponse;
-import com.delivery.justonebite.order.presentation.dto.response.GetOrderStatusResponse.OrderHistoryDto;
+import com.delivery.justonebite.order.presentation.dto.response.OrderCancelResponse;
 import com.delivery.justonebite.order.presentation.dto.response.OrderDetailsResponse;
 import com.delivery.justonebite.user.domain.entity.User;
 import com.delivery.justonebite.user.domain.entity.UserRole;
 import com.delivery.justonebite.user.domain.repository.UserRepository;
 import com.delivery.justonebite.shop.domain.entity.Shop;
 import com.delivery.justonebite.shop.domain.repository.ShopRepository;
-import com.delivery.justonebite.user.domain.entity.User;
-import com.delivery.justonebite.user.domain.entity.UserRole;
-import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -155,6 +150,55 @@ public class OrderService {
         return GetOrderStatusResponse.toDto(orderId, histories);
     }
 
+    @Transactional
+    public OrderCancelResponse cancelOrder(CancelOrderRequest request, UUID orderId, User user) {
+        // 취소 요청만 허용
+        if (!OrderStatus.ORDER_CANCELLED.name().equals(request.status())) {
+            throw new CustomException(ErrorCode.INVALID_CANCEL_STATUS_VALUE);
+        }
+
+        authorizeCustomer(user);
+
+        // TODO: 두 번의 DB 조회를 수행함. 추후 ORDER 엔티티에 currentStatus 필드 추가하면서 수정될 예정
+        Order order = orderRepository.findByIdWithCustomer(orderId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        OrderHistory currentHistory = orderHistoryRepository.findTopByOrder_IdOrderByCreatedAtDesc(orderId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 현재 로그인한 사용자가 주문자와 동일하지 않을 경우
+        if (!user.equals(order.getCustomer())) {
+            throw new CustomException(ErrorCode.ORDER_USER_NOT_MATCH);
+        }
+
+        validateCancellationTime(order.getCreatedAt());
+
+        if (currentHistory.getStatus() != OrderStatus.PENDING) {
+            throw new CustomException(ErrorCode.ORDER_STATUS_CANCEL_NOT_ALLOWED);
+        }
+
+        orderHistoryRepository.save(OrderHistory.create(order, OrderStatus.ORDER_CANCELLED));
+
+        return OrderCancelResponse.toDto(order, OrderStatus.ORDER_CANCELLED, LocalDateTime.now());
+    }
+
+    private void validateCancellationTime(LocalDateTime createdAt) {
+        // TODO: Order 객체에 currentStatus 필드 추가하여 취소 행위를 위임하도록 수정해야 함
+        // 시간 검증, 상태 검증, 상태 변경이 모두 Order 객체 내부에서 일어나도록
+
+        // 취소 제한 시간 (5분)
+        final long CANCEL_LIMIT_SECONDS = 5 * 60;
+        LocalDateTime now = LocalDateTime.now();
+
+        // 현재 시간과 주문 생성 시간의 차이 계산
+        long elapsed = ChronoUnit.SECONDS.between(createdAt, now);
+
+        // 5분이 지났다면
+        if (elapsed >= CANCEL_LIMIT_SECONDS) {
+            throw new CustomException(ErrorCode.ORDER_CANCEL_TIME_EXCEEDED);
+        }
+    }
+
     private void authorizeOwner(User user) {
         authorizeUser(user);
         if (!(user.getUserRole().equals(UserRole.OWNER))) {
@@ -221,39 +265,5 @@ public class OrderService {
             return orderRepository.existsByIdAndShop_Owner(orderId, user.getId());
         }
         return false;
-    }
-
-    @Transactional
-    public void cancelOrder(UUID orderId, User user) {
-        Order order = orderRepository.findById(orderId)
-            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
-        OrderHistory currentHistory = orderHistoryRepository.findTopByOrder_IdOrderByCreatedAtDesc(orderId)
-            .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
-        validateCancellationTime(order.getCreatedAt());
-
-        if (currentHistory.getStatus() != OrderStatus.PENDING) {
-            throw new CustomException(ErrorCode.ORDER_STATUS_CANCEL_NOT_ALLOWED);
-        }
-
-        orderHistoryRepository.save(OrderHistory.create(order, OrderStatus.ORDER_CANCELLED));
-    }
-
-    private void validateCancellationTime(LocalDateTime createdAt) {
-        // TODO: Order 객체에 currentStatus 필드 추가하여 취소 행위를 위임하도록 수정해야 함
-        // 시간 검증, 상태 검증, 상태 변경이 모두 Order 객체 내부에서 일어나도록
-
-        // 취소 제한 시간 (5분)
-        final long CANCEL_LIMIT_SECONDS = 5 * 60;
-        LocalDateTime now = LocalDateTime.now();
-
-        // 현재 시간과 주문 생성 시간의 차이 계산
-        long elapsed = ChronoUnit.SECONDS.between(createdAt, now);
-
-        // 5분이 지났다면
-        if (elapsed >= CANCEL_LIMIT_SECONDS) {
-            throw new CustomException(ErrorCode.ORDER_CANCEL_TIME_EXCEEDED);
-        }
     }
 }

--- a/src/main/java/com/delivery/justonebite/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/delivery/justonebite/order/domain/repository/OrderRepository.java
@@ -1,14 +1,24 @@
 package com.delivery.justonebite.order.domain.repository;
 
 import com.delivery.justonebite.order.domain.entity.Order;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
 
     boolean existsByIdAndCustomer_Id(UUID id, Long userId);
 
     boolean existsByIdAndShop_Owner(UUID id, Long userId);
+
+    /**
+     * JOIN FETCH o.customer : INNER JOIN h_user u ON o.user_id = u.user_id
+     * 조회된 customer 엔티티를 즉시 로딩 대상으로 지정
+     */
+    @Query("SELECT o FROM Order o JOIN FETCH o.customer WHERE o.id = :orderId")
+    Optional<Order> findByIdWithCustomer(@Param("orderId") UUID orderId);
 }
 /**
  * // OrderRepository.java

--- a/src/main/java/com/delivery/justonebite/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/delivery/justonebite/order/presentation/controller/OrderController.java
@@ -3,16 +3,19 @@ package com.delivery.justonebite.order.presentation.controller;
 import com.delivery.justonebite.global.common.security.UserDetailsImpl;
 import com.delivery.justonebite.order.application.service.OrderService;
 import com.delivery.justonebite.order.domain.entity.Order;
+import com.delivery.justonebite.order.presentation.dto.request.CancelOrderRequest;
 import com.delivery.justonebite.order.presentation.dto.request.CreateOrderRequest;
 import com.delivery.justonebite.order.presentation.dto.request.UpdateOrderStatusRequest;
 import com.delivery.justonebite.order.presentation.dto.response.CustomerOrderResponse;
 import com.delivery.justonebite.order.presentation.dto.response.GetOrderStatusResponse;
+import com.delivery.justonebite.order.presentation.dto.response.OrderCancelResponse;
 import com.delivery.justonebite.order.presentation.dto.response.OrderDetailsResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.apache.catalina.User;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
@@ -81,9 +84,11 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @DeleteMapping("/{order-id}")
-    public ResponseEntity<Void> cancelOrder(@PathVariable(name = "order-id") UUID orderId,
+    @PatchMapping("/{order-id}")
+    public ResponseEntity<OrderCancelResponse> cancelOrder(@Valid @RequestBody CancelOrderRequest request,
+        @PathVariable(name = "order-id") UUID orderId,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        orderService.cancelOrder(orderId, userDetails.getUser());
+        OrderCancelResponse response = orderService.cancelOrder(request, orderId, userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/delivery/justonebite/order/presentation/dto/request/CancelOrderRequest.java
+++ b/src/main/java/com/delivery/justonebite/order/presentation/dto/request/CancelOrderRequest.java
@@ -1,0 +1,9 @@
+package com.delivery.justonebite.order.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CancelOrderRequest(
+    @NotNull(message = "상태값은 필수입니다.")
+    String status
+) {
+}

--- a/src/main/java/com/delivery/justonebite/order/presentation/dto/response/OrderCancelResponse.java
+++ b/src/main/java/com/delivery/justonebite/order/presentation/dto/response/OrderCancelResponse.java
@@ -1,0 +1,24 @@
+package com.delivery.justonebite.order.presentation.dto.response;
+
+import com.delivery.justonebite.order.domain.entity.Order;
+import com.delivery.justonebite.order.domain.enums.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record OrderCancelResponse(
+    UUID orderId,
+    String orderStatus,
+    Integer refund, // 쿠폰이나 포인트 사용했을 경우, 실제 결제 금액과 다를 수 있으나 현재 시스템에서는 따로 고려하지 않고 있습니다. 참고 바랍니다.
+    LocalDateTime cancelledAt
+) {
+    public static OrderCancelResponse toDto(Order order, OrderStatus status, LocalDateTime cancelledAt) {
+        return OrderCancelResponse.builder()
+            .orderId(order.getId())
+            .orderStatus(status.name())
+            .refund(order.getTotalPrice())
+            .cancelledAt(cancelledAt)
+            .build();
+    }
+}

--- a/src/main/java/com/delivery/justonebite/user/domain/entity/User.java
+++ b/src/main/java/com/delivery/justonebite/user/domain/entity/User.java
@@ -3,6 +3,7 @@ package com.delivery.justonebite.user.domain.entity;
 import com.delivery.justonebite.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -13,6 +14,7 @@ import org.hibernate.type.SqlTypes;
 @SuperBuilder
 @Entity
 @Table(name = "h_user")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- #57 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 주문 취소 API 개발
- 현재 로그인한 사용자와 주문자가 동일한지 검증을 위해 User 엔티티에 Lombok의 @EqualsAndHashCode 어노테이션 추가
- 주문 취소 가능 상태 검증 (주문 시점으로부터 5분 이내, 주문 상태가 PENDING 일 때에만)
- 예외 처리
- 🔴 Order 테이블에 currentStatus를 추가하기로 하여 (OrderHistory의 상태 필드값은 그대로 두고.. 동기화 처리로 관리) 해당 작업 이후에 주문 취소 기능의 비즈니스 로직도 꽤 많이 달라질 예정입니다. (대표적으로 cancel 관련한 비즈니스 로직들을 Order 도메인에 위임하도록 수정할 예정) 리뷰에 참고 바랍니다.

## 💫 타입

- [x] 기능
- [ ] 버그
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
