### PR TITLE
154-fix: 중복 카테고리 관련 수정 및 ShopRepository 쿼리 변경

### DIFF
--- a/src/main/java/com/delivery/justonebite/shop/application/service/ShopQueryService.java
+++ b/src/main/java/com/delivery/justonebite/shop/application/service/ShopQueryService.java
@@ -59,11 +59,12 @@ public class ShopQueryService {
 
         // Projection -> Map 변환
         Map<UUID, BigDecimal> avgMap = avgList.stream()
+                .filter(a -> a.getShopId() != null)
                 .collect(Collectors.toMap(
                         ShopAvgProjection::getShopId,
-                        ShopAvgProjection::getAverageRating
+                        ShopAvgProjection::getAverageRating,
+                        (existing, duplicate) -> existing // 중복 발생 시 기존 값 유지
                 ));
-
 
         // DTO 변환
         return shops.map(shop -> {

--- a/src/main/java/com/delivery/justonebite/shop/application/service/ShopService.java
+++ b/src/main/java/com/delivery/justonebite/shop/application/service/ShopService.java
@@ -30,9 +30,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -47,10 +45,10 @@ public class ShopService {
     private final OrderItemRepository orderItemRepository;
 
 
-    //가게 등록
+    // 가게 등록
     @Transactional
     public Shop createShop(ShopCreateRequest request, Long userId, UserRole role) {
-        //권한 체크
+        // 권한 체크
         if (role != UserRole.OWNER) {
             throw new CustomException(ErrorCode.INVALID_USER_ROLE);
         }
@@ -59,25 +57,26 @@ public class ShopService {
 
         List<String> categoryNames = request.categories();
         if (categoryNames != null && !categoryNames.isEmpty()) {
-            //기존 카테고리 조회 (한 번에 IN 쿼리)
-            Map<String, Category> existingByName = categoryRepository
-                    .findAllByCategoryNameIn(categoryNames).stream()
-                    .collect(Collectors.toMap(Category::getCategoryName, c -> c));
 
-            //없는 카테고리는 새로 생성
-            for (String categoryName : categoryNames) {
-                Category category = existingByName.get(categoryName);
-                if (category == null) {
-                    category = categoryRepository.save(
-                            Category.builder()
-                                    .categoryName(categoryName)
-                                    .build()
-                    );
-                    existingByName.put(categoryName, category); // 새로 추가된 카테고리도 Map에 넣기
-                }
+            // DB에 존재하는 카테고리만 조회 (없는 건 예외)
+            List<Category> foundCategories = categoryRepository.findAllByCategoryNameIn(categoryNames);
 
-                //ShopCategory 관계 추가
-                shop.addCategory(category);
+            // 요청 중 실제 존재하지 않는 카테고리명 필터링
+            Set<String> foundNames = foundCategories.stream()
+                    .map(Category::getCategoryName)
+                    .collect(Collectors.toSet());
+
+            List<String> notFound = categoryNames.stream()
+                    .filter(name -> !foundNames.contains(name))
+                    .toList();
+
+            if (!notFound.isEmpty()) {
+                throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+            }
+
+            // ShopCategory 관계 추가
+            for (Category category : foundCategories) {
+                shop.addCategory(category); // 중복 방지 로직 포함
             }
         }
 
@@ -89,16 +88,17 @@ public class ShopService {
     public ShopUpdateResponse updateShop(ShopUpdateRequest request, UUID shopId, Long userId, UserRole role) {
         Shop shop = shopRepository.findById(shopId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SHOP_NOT_FOUND));
+
         // 권한 체크
         if (!(role == UserRole.OWNER || role == UserRole.MASTER || role == UserRole.MANAGER)) {
             throw new CustomException(ErrorCode.INVALID_USER_ROLE);
         }
-        // OWNER 본인 가게 여부 확인
+
         if (role == UserRole.OWNER && !shop.getOwnerId().equals(userId)) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_SHOP_ACCESS);
         }
 
-        // 1. 변경된 필드 수정
+        // 필드 업데이트
         shop.updateInfo(
                 request.name(),
                 request.phone_number(),
@@ -106,18 +106,68 @@ public class ShopService {
                 request.description()
         );
 
-        // 2. 카테고리 문자열 → Category 엔티티 변환
-        if (request.categories() != null && !request.categories().isEmpty()) {
-            shop.getCategories().clear();
-            for (String categoryName : request.categories()) {
-                Category category = categoryRepository.findByCategoryName(categoryName)
-                        .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
-                ShopCategory sc = ShopCategory.builder().shop(shop).category(category).build();
-                shop.getCategories().add(sc);
+        // 카테고리 수정
+        if (request.categories() != null) {
+            Set<String> currentNames = shop.getCategories().stream()
+                    .map(sc -> sc.getCategory().getCategoryName())
+                    .collect(Collectors.toSet());
+
+            Set<String> newNames = new HashSet<>(request.categories());
+
+            // 아무 변화도 없으면 skip
+            if (!currentNames.equals(newNames)) {
+
+                // 삭제할 카테고리: 현재엔 있지만 새 목록엔 없는 것
+                Set<String> toRemove = currentNames.stream()
+                        .filter(name -> !newNames.contains(name))
+                        .collect(Collectors.toSet());
+
+                // 추가할 카테고리: 새 목록엔 있지만 현재엔 없는 것
+                Set<String> toAdd = newNames.stream()
+                        .filter(name -> !currentNames.contains(name))
+                        .collect(Collectors.toSet());
+
+                // 삭제
+                shop.getCategories().removeIf(sc -> toRemove.contains(sc.getCategory().getCategoryName()));
+
+                if (!toAdd.isEmpty()) {
+                    List<Category> found = categoryRepository.findAllByCategoryNameIn(new ArrayList<>(toAdd));
+
+                    // DB에 존재하는 카테고리 이름 set
+                    Set<String> foundNames = found.stream()
+                            .map(Category::getCategoryName)
+                            .collect(Collectors.toSet());
+
+                    // 존재하지 않는 이름
+                    List<String> notFound = toAdd.stream()
+                            .filter(name -> !foundNames.contains(name))
+                            .toList();
+
+                    // 없는 카테고리는 새로 생성
+                    for (String name : notFound) {
+                        Category newCategory = categoryRepository.save(Category.builder()
+                                .categoryName(name)
+                                .build());
+                        found.add(newCategory);
+                    }
+
+                    // ShopCategory 추가
+                    for (Category category : found) {
+                        shop.getCategories().add(
+                                ShopCategory.builder()
+                                        .shop(shop)
+                                        .category(category)
+                                        .build()
+                        );
+                    }
+                }
             }
         }
-        return new ShopUpdateResponse(shop.getUpdatedAt(),shop.getUpdatedBy());
+
+            return new ShopUpdateResponse(shop.getUpdatedAt(), shop.getUpdatedBy());
+
     }
+
 
     //가게 삭제
     @Transactional

--- a/src/main/java/com/delivery/justonebite/shop/domain/entity/Shop.java
+++ b/src/main/java/com/delivery/justonebite/shop/domain/entity/Shop.java
@@ -1,8 +1,6 @@
 package com.delivery.justonebite.shop.domain.entity;
 
 import com.delivery.justonebite.global.common.entity.BaseEntity;
-import com.delivery.justonebite.shop.presentation.dto.request.ShopUpdateRequest;
-import com.delivery.justonebite.user.domain.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -10,11 +8,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -66,6 +64,7 @@ public class Shop extends BaseEntity {
     private BigDecimal averageRating = BigDecimal.valueOf(0.0);
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "create_accept_status", nullable = false)
     @Builder.Default
     private AcceptStatus createAcceptStatus = AcceptStatus.PENDING;
@@ -74,6 +73,7 @@ public class Shop extends BaseEntity {
     private String createRejectReason;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "delete_accept_status", nullable = false)
     @Builder.Default
     private RejectStatus deleteAcceptStatus = RejectStatus.NONE;
@@ -89,11 +89,13 @@ public class Shop extends BaseEntity {
 
     //가게 등록
     public void addCategory(Category category) {
-        ShopCategory shopCategory = ShopCategory.create(this, category);
-        if (!this.categories.contains(shopCategory)) {
-            this.categories.add(shopCategory);
+        boolean exists = this.categories.stream()
+                .anyMatch(sc -> sc.getCategory().equals(category));
+        if (!exists) {
+            this.categories.add(ShopCategory.create(this, category));
         }
     }
+
 
     //가게 수정
     public void updateInfo(String name, String phone, String operatingHour, String description) {

--- a/src/main/java/com/delivery/justonebite/shop/domain/repository/ShopRepository.java
+++ b/src/main/java/com/delivery/justonebite/shop/domain/repository/ShopRepository.java
@@ -29,7 +29,7 @@ public interface ShopRepository extends JpaRepository<Shop, UUID> {
     //리뷰 평점 관련 코드 --
 
 
-    @Query("select s.id as id, s.averageRating as averageRating from Shop s where s.id in :ids")
+    @Query("select s.id as shopId, s.averageRating as averageRating from Shop s where s.id in :ids")
     List<ShopAvgProjection> findAvgByIds(@Param("ids") List<UUID> ids);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 이슈 번호
- 154

## 💬 요약
가게 수정시 이미 있는 카테고리를 그대로 작성하면 error ->에러 없이 update 하지 않는 방식으로 변경
일부 수정하여도 수정된 부분만 update 되지 않고 error가 생김 -> 수정된 부분만 update, error 안뜨도록 수정

가게 조회 시 shopRepository와 ShopAvgProjection간 컬럼명 불일치

## 💫 타입

- [ ] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 
